### PR TITLE
[BugFix] Fix appendcol MAP sub-path resolution (#5186)

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
@@ -22,6 +22,7 @@ import static org.opensearch.sql.calcite.utils.PlanUtils.ROW_NUMBER_COLUMN_FOR_S
 import static org.opensearch.sql.calcite.utils.PlanUtils.ROW_NUMBER_COLUMN_FOR_SUBSEARCH;
 import static org.opensearch.sql.calcite.utils.PlanUtils.getRelation;
 import static org.opensearch.sql.calcite.utils.PlanUtils.getRexCall;
+import static org.opensearch.sql.calcite.utils.PlanUtils.getSourcePreamble;
 import static org.opensearch.sql.calcite.utils.PlanUtils.transformPlanToAttachChild;
 import static org.opensearch.sql.utils.SystemIndexUtils.DATASOURCES_TABLE_NAME;
 
@@ -2435,7 +2436,7 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
         context.relBuilder.alias(mainRowNumber, ROW_NUMBER_COLUMN_FOR_MAIN));
 
     // 3. build subsearch tree (attach relation to subsearch)
-    UnresolvedPlan relation = getRelation(node);
+    UnresolvedPlan relation = getSourcePreamble(node);
     transformPlanToAttachChild(node.getSubSearch(), relation);
     // 4. resolve subsearch plan
     node.getSubSearch().accept(this, context);

--- a/core/src/main/java/org/opensearch/sql/calcite/utils/PlanUtils.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/PlanUtils.java
@@ -68,6 +68,7 @@ import org.opensearch.sql.ast.expression.SpanUnit;
 import org.opensearch.sql.ast.expression.WindowBound;
 import org.opensearch.sql.ast.expression.WindowFrame;
 import org.opensearch.sql.ast.tree.Relation;
+import org.opensearch.sql.ast.tree.SPath;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
 import org.opensearch.sql.calcite.CalcitePlanContext;
 import org.opensearch.sql.expression.function.BuiltinFunctionName;
@@ -406,6 +407,43 @@ public interface PlanUtils {
           }
         };
     return node.getChild().getFirst().accept(relationVisitor, null);
+  }
+
+  /**
+   * Extract the source preamble from the main pipeline for the appendcol subsearch base.
+   * Includes the leaf Relation and any SPath nodes, preserving schema transformations
+   * (e.g., spath converts STRING columns to MAP type).
+   */
+  static UnresolvedPlan getSourcePreamble(UnresolvedPlan node) {
+    List<SPath> spathNodes = new ArrayList<>();
+    UnresolvedPlan current = (UnresolvedPlan) node.getChild().getFirst();
+    Relation relation = null;
+    while (current != null) {
+      if (current instanceof Relation r) {
+        relation = r;
+        break;
+      }
+      if (current instanceof SPath s) {
+        spathNodes.add(s);
+      }
+      List<?> children = current.getChild();
+      if (children != null && !children.isEmpty()) {
+        current = (UnresolvedPlan) children.getFirst();
+      } else {
+        break;
+      }
+    }
+    if (relation == null) {
+      return getRelation(node);
+    }
+    UnresolvedPlan result = relation;
+    for (int i = spathNodes.size() - 1; i >= 0; i--) {
+      SPath orig = spathNodes.get(i);
+      result =
+          new SPath(
+              result, orig.getInField(), orig.getOutField(), orig.getPath());
+    }
+    return result;
   }
 
   /** Similar to {@link org.apache.calcite.plan.RelOptUtil#findTable(RelNode, String) } */


### PR DESCRIPTION
## Summary
- Fixes appendcol subquery failing with `INTERNAL_ITEM function expects {[ARRAY,INTEGER]|[STRUCT,ANY]}, but got [STRING,STRING]` when the main pipeline uses `spath` to convert STRING columns to MAP type
- Root cause: `appendcol` subsearch always started from the raw source relation, ignoring `spath` schema transformations
- Fix: new `getSourcePreamble()` method in PlanUtils walks the main pipeline AST chain and propagates SPath nodes to the subsearch base, so MAP sub-paths like `doc.user.city` resolve correctly

## Test plan
- [ ] Unit test: appendcol with spath auto-extract mode resolves MAP sub-paths
- [ ] Unit test: appendcol with spath path mode preserves schema
- [ ] Existing appendcol tests continue to pass (no SPath nodes means fallback to getRelation)
- [ ] Integration test with real OpenSearch index containing JSON string field

Resolves opensearch-project/sql#5186