### PR TITLE
[BugFix] Fix dedup pushdown nullifying renamed fields (#5150)

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/calcite/CalciteNoPushdownIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/CalciteNoPushdownIT.java
@@ -69,6 +69,7 @@ import org.opensearch.sql.ppl.PPLIntegTestCase;
   CalcitePPLConditionBuiltinFunctionIT.class,
   CalcitePPLCryptographicFunctionIT.class,
   CalcitePPLDedupIT.class,
+  CalciteDedupRenameIT.class,
   CalcitePPLEventstatsIT.class,
   CalciteStreamstatsCommandIT.class,
   CalcitePPLExistsSubqueryIT.class,

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteDedupRenameIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteDedupRenameIT.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.remote;
+
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_DUPLICATION_NULLABLE;
+import static org.opensearch.sql.util.MatcherUtils.*;
+
+import java.io.IOException;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.opensearch.sql.ppl.PPLIntegTestCase;
+
+/**
+ * Integration test for GitHub issue #5150: Dedup aggregation pushdown nullifies renamed fields.
+ *
+ * <p>When a field is renamed via the rename command and a subsequent dedup command operates on a
+ * different field, the renamed field should retain its original values.
+ */
+public class CalciteDedupRenameIT extends PPLIntegTestCase {
+
+  @Override
+  public void init() throws Exception {
+    super.init();
+    enableCalcite();
+
+    loadIndex(Index.DUPLICATION_NULLABLE);
+  }
+
+  @Test
+  public void testRenameThenDedupRetainsRenamedFieldValues() throws IOException {
+    // Rename 'name' to 'n', then dedup by 'category' -- 'n' should not be null
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | rename name as n | dedup category | fields category, n",
+                TEST_INDEX_DUPLICATION_NULLABLE));
+    verifyDataRows(actual, rows("X", "A"), rows("Y", "A"), rows("Z", "B"));
+  }
+
+  @Test
+  public void testRenameMultipleFieldsThenDedupRetainsAllValues() throws IOException {
+    // Rename both 'name' and 'category', then dedup by renamed 'category'
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | rename name as n, category as cat | dedup cat | fields cat, n",
+                TEST_INDEX_DUPLICATION_NULLABLE));
+    verifyDataRows(actual, rows("X", "A"), rows("Y", "A"), rows("Z", "B"));
+  }
+
+  @Test
+  public void testRenameDedupFieldItselfWorks() throws IOException {
+    // Rename the dedup field itself -- this should already work
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | rename category as cat | dedup cat | fields cat, name",
+                TEST_INDEX_DUPLICATION_NULLABLE));
+    verifyDataRows(actual, rows("X", "A"), rows("Y", "A"), rows("Z", "B"));
+  }
+}

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/5150.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/5150.yml
@@ -1,0 +1,83 @@
+setup:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled: true
+
+  - do:
+      indices.create:
+        index: issue5150
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+          mappings:
+            properties:
+              count:
+                type: integer
+              category:
+                type: keyword
+              subcategory:
+                type: keyword
+              value:
+                type: double
+              ts:
+                type: date
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "issue5150", "_id": "1"}}'
+          - '{"count":1,"category":"A","subcategory":"X","value":10.5,"ts":"2024-01-01"}'
+          - '{"index": {"_index": "issue5150", "_id": "2"}}'
+          - '{"count":2,"category":"A","subcategory":"Y","value":20.3,"ts":"2024-01-02"}'
+          - '{"index": {"_index": "issue5150", "_id": "3"}}'
+          - '{"count":10,"category":"B","subcategory":"X","value":100.0,"ts":"2024-01-03"}'
+          - '{"index": {"_index": "issue5150", "_id": "4"}}'
+          - '{"count":5,"category":"C","subcategory":"Z","value":50.0,"ts":"2024-01-04"}'
+
+---
+teardown:
+  - do:
+      indices.delete:
+        index: issue5150
+        ignore_unavailable: true
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled: false
+
+---
+"Issue 5150: rename then dedup should retain renamed field values":
+  - skip:
+      features:
+        - headers
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: source=issue5150 | rename value as val | dedup category | fields category, val
+
+  - match: { total: 3 }
+  - match: { schema: [ { name: category, type: string }, { name: val, type: double } ] }
+  - length: { datarows: 3 }
+
+---
+"Issue 5150: rename multiple fields then dedup should retain all renamed values":
+  - skip:
+      features:
+        - headers
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: source=issue5150 | rename value as val, category as cat | dedup cat | fields cat, val
+
+  - match: { total: 3 }
+  - match: { schema: [ { name: cat, type: string }, { name: val, type: double } ] }
+  - length: { datarows: 3 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/request/AggregateAnalyzer.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/request/AggregateAnalyzer.java
@@ -38,6 +38,7 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -601,7 +602,21 @@ public class AggregateAnalyzer {
         TopHitsAggregationBuilder topHitsAggregationBuilder =
             createTopHitsBuilder(
                 aggCall, args, aggName, helper, dedupNumber, false, false, null, null);
-        yield Pair.of(topHitsAggregationBuilder, new TopHitsParser(aggName, false, false));
+        // Build rename mapping: original index field name -> renamed project field name.
+        // This is needed because the OpenSearch response uses original field names in
+        // top_hits _source/fields, but the query schema expects renamed field names.
+        Map<String, String> fieldRenameMap = new HashMap<>();
+        for (Pair<RexNode, String> arg : args) {
+          if (arg.getKey() instanceof RexInputRef) {
+            String originalName = helper.inferNamedField(arg.getKey()).getRootName();
+            String renamedName = arg.getValue();
+            if (!originalName.equals(renamedName)) {
+              fieldRenameMap.put(originalName, renamedName);
+            }
+          }
+        }
+        yield Pair.of(
+            topHitsAggregationBuilder, new TopHitsParser(aggName, false, false, fieldRenameMap));
       }
       default ->
           throw new AggregateAnalyzer.AggregateAnalyzerException(

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/response/agg/TopHitsParser.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/response/agg/TopHitsParser.java
@@ -27,10 +27,26 @@ public class TopHitsParser implements MetricParser {
   private final boolean returnSingleValue;
   private final boolean returnMergeValue;
 
+  /**
+   * Mapping from original index field names to renamed field names. Used when fields are renamed
+   * (e.g., via PPL rename command) before a dedup aggregation pushdown. The OpenSearch response
+   * returns original field names, but the query schema expects renamed names.
+   */
+  private final Map<String, String> fieldRenameMap;
+
   public TopHitsParser(String name, boolean returnSingleValue, boolean returnMergeValue) {
+    this(name, returnSingleValue, returnMergeValue, Collections.emptyMap());
+  }
+
+  public TopHitsParser(
+      String name,
+      boolean returnSingleValue,
+      boolean returnMergeValue,
+      Map<String, String> fieldRenameMap) {
     this.name = name;
     this.returnSingleValue = returnSingleValue;
     this.returnMergeValue = returnMergeValue;
+    this.fieldRenameMap = fieldRenameMap;
   }
 
   @Override
@@ -129,10 +145,26 @@ public class TopHitsParser implements MetricParser {
                         ? new LinkedHashMap<>()
                         : new LinkedHashMap<>(hit.getSourceAsMap());
                 hit.getFields().values().forEach(f -> map.put(f.getName(), f.getValue()));
-                return map;
+                return applyFieldRenameMap(map);
               })
           .toList();
     }
+  }
+
+  /**
+   * Apply field rename mapping to the result map. Renames keys from original index field names to
+   * their renamed aliases as expected by the query schema.
+   */
+  private Map<String, Object> applyFieldRenameMap(Map<String, Object> map) {
+    if (fieldRenameMap.isEmpty()) {
+      return map;
+    }
+    Map<String, Object> renamed = new LinkedHashMap<>();
+    for (Map.Entry<String, Object> entry : map.entrySet()) {
+      String key = fieldRenameMap.getOrDefault(entry.getKey(), entry.getKey());
+      renamed.put(key, entry.getValue());
+    }
+    return renamed;
   }
 
   private boolean isEmptyHits(SearchHit[] hits) {

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/response/OpenSearchAggregationResponseParserTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/response/OpenSearchAggregationResponseParserTest.java
@@ -578,6 +578,123 @@ class OpenSearchAggregationResponseParserTest {
     return ImmutableMap.of(name, value);
   }
 
+  /**
+   * Tests that TopHitsParser correctly renames fields when a fieldRenameMap is provided. This is
+   * the fix for GitHub issue #5150: dedup aggregation pushdown nullifies renamed fields.
+   */
+  @Test
+  void top_hits_with_field_rename_map_should_rename_response_fields() {
+    // Simulates: source=idx | rename value as val | dedup category | fields category, val
+    // The composite bucket key uses renamed "category", and top_hits returns original "value".
+    String response =
+        "{\n"
+            + "  \"composite#composite_buckets\": {\n"
+            + "    \"buckets\": [\n"
+            + "      {\n"
+            + "        \"key\": {\n"
+            + "          \"category\": \"A\"\n"
+            + "        },\n"
+            + "        \"doc_count\": 2,\n"
+            + "        \"top_hits#dedup\": {\n"
+            + "          \"hits\": {\n"
+            + "            \"total\": { \"value\": 2, \"relation\": \"eq\" },\n"
+            + "            \"max_score\": 1.0,\n"
+            + "            \"hits\": [\n"
+            + "              {\n"
+            + "                \"_index\": \"idx\",\n"
+            + "                \"_id\": \"1\",\n"
+            + "                \"_score\": 1.0,\n"
+            + "                \"fields\": {\n"
+            + "                  \"value\": [10.5]\n"
+            + "                }\n"
+            + "              }\n"
+            + "            ]\n"
+            + "          }\n"
+            + "        }\n"
+            + "      },\n"
+            + "      {\n"
+            + "        \"key\": {\n"
+            + "          \"category\": \"B\"\n"
+            + "        },\n"
+            + "        \"doc_count\": 1,\n"
+            + "        \"top_hits#dedup\": {\n"
+            + "          \"hits\": {\n"
+            + "            \"total\": { \"value\": 1, \"relation\": \"eq\" },\n"
+            + "            \"max_score\": 1.0,\n"
+            + "            \"hits\": [\n"
+            + "              {\n"
+            + "                \"_index\": \"idx\",\n"
+            + "                \"_id\": \"3\",\n"
+            + "                \"_score\": 1.0,\n"
+            + "                \"fields\": {\n"
+            + "                  \"value\": [100.0]\n"
+            + "                }\n"
+            + "              }\n"
+            + "            ]\n"
+            + "          }\n"
+            + "        }\n"
+            + "      }\n"
+            + "    ]\n"
+            + "  }\n"
+            + "}";
+    // TopHitsParser with fieldRenameMap: "value" -> "val"
+    OpenSearchAggregationResponseParser parser =
+        new CompositeAggregationParser(
+            new TopHitsParser("dedup", false, false, Map.of("value", "val")));
+    List<Map<String, Object>> result = parse(parser, response);
+    // Each bucket produces two maps: one for the composite key, one for the top_hits fields.
+    // The top_hits map should use "val" instead of "value".
+    assertThat(
+        result,
+        contains(
+            ImmutableMap.of("category", "A"),
+            ImmutableMap.of("val", 10.5),
+            ImmutableMap.of("category", "B"),
+            ImmutableMap.of("val", 100.0)));
+  }
+
+  /**
+   * Tests TopHitsParser without fieldRenameMap works as before (backward compatibility). Same
+   * response as above but with the default 3-arg constructor.
+   */
+  @Test
+  void top_hits_without_field_rename_map_should_use_original_field_names() {
+    String response =
+        "{\n"
+            + "  \"composite#composite_buckets\": {\n"
+            + "    \"buckets\": [\n"
+            + "      {\n"
+            + "        \"key\": {\n"
+            + "          \"category\": \"A\"\n"
+            + "        },\n"
+            + "        \"doc_count\": 1,\n"
+            + "        \"top_hits#dedup\": {\n"
+            + "          \"hits\": {\n"
+            + "            \"total\": { \"value\": 1, \"relation\": \"eq\" },\n"
+            + "            \"max_score\": 1.0,\n"
+            + "            \"hits\": [\n"
+            + "              {\n"
+            + "                \"_index\": \"idx\",\n"
+            + "                \"_id\": \"1\",\n"
+            + "                \"_score\": 1.0,\n"
+            + "                \"fields\": {\n"
+            + "                  \"value\": [10.5]\n"
+            + "                }\n"
+            + "              }\n"
+            + "            ]\n"
+            + "          }\n"
+            + "        }\n"
+            + "      }\n"
+            + "    ]\n"
+            + "  }\n"
+            + "}";
+    // TopHitsParser without fieldRenameMap (3-arg constructor)
+    OpenSearchAggregationResponseParser parser =
+        new CompositeAggregationParser(new TopHitsParser("dedup", false, false));
+    List<Map<String, Object>> result = parse(parser, response);
+    assertThat(result, contains(ImmutableMap.of("category", "A"), ImmutableMap.of("value", 10.5)));
+  }
+
   public Map<String, Object> entry(String name, Object value, String name2, Object value2) {
     return ImmutableMap.of(name, value, name2, value2);
   }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLDedupTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLDedupTest.java
@@ -272,4 +272,32 @@ public class CalcitePPLDedupTest extends CalcitePPLAbstractTest {
             + "            LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
   }
+
+  /** Test for issue #5150: rename then dedup should produce correct logical plan. */
+  @Test
+  public void testRenameThenDedup() {
+    String ppl = "source=EMP | rename ENAME as employee | dedup DEPTNO | fields DEPTNO, employee";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalProject(DEPTNO=[$7], employee=[$1])\n"
+            + "  LogicalFilter(condition=[<=($8, 1)])\n"
+            + "    LogicalProject(EMPNO=[$0], employee=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
+            + " SAL=[$5], COMM=[$6], DEPTNO=[$7], _row_number_dedup_=[ROW_NUMBER() OVER (PARTITION"
+            + " BY $7)])\n"
+            + "      LogicalFilter(condition=[IS NOT NULL($7)])\n"
+            + "        LogicalProject(EMPNO=[$0], employee=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
+            + " SAL=[$5], COMM=[$6], DEPTNO=[$7])\n"
+            + "          LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+    String expectedSparkSql =
+        "SELECT `DEPTNO`, `employee`\n"
+            + "FROM (SELECT `EMPNO`, `employee`, `JOB`, `MGR`, `HIREDATE`, `SAL`, `COMM`,"
+            + " `DEPTNO`, ROW_NUMBER() OVER (PARTITION BY `DEPTNO`) `_row_number_dedup_`\n"
+            + "FROM (SELECT `EMPNO`, `ENAME` `employee`, `JOB`, `MGR`, `HIREDATE`, `SAL`, `COMM`,"
+            + " `DEPTNO`\n"
+            + "FROM `scott`.`EMP`) `t`\n"
+            + "WHERE `DEPTNO` IS NOT NULL) `t1`\n"
+            + "WHERE `_row_number_dedup_` <= 1";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
 }


### PR DESCRIPTION
## Summary
- Fixes GitHub issue opensearch-project/sql#5150: when a field is renamed via `rename` and a subsequent `dedup` operates on a different field, the aggregation-based dedup pushdown path returned null for renamed fields
- Root cause: OpenSearch `top_hits` response uses original index field names, but the query schema expects renamed names after `rename` command
- Fix: builds a rename mapping in `AggregateAnalyzer` for the `LITERAL_AGG` (dedup pushdown) case and passes it to `TopHitsParser`, which applies the mapping when constructing result maps

## Test plan
- [x] Unit test: `TopHitsParser` with `fieldRenameMap` in `OpenSearchAggregationResponseParserTest`
- [x] Unit test: rename+dedup logical plan in `CalcitePPLDedupTest`
- [x] Integration test: `CalciteDedupRenameIT` (3 test cases covering rename+dedup, multiple renames+dedup, rename dedup field itself)
- [x] YAML REST test: `issues/5150.yml` (2 test cases)
- [x] All tests pass with pushdown enabled and disabled (via `CalciteNoPushdownIT` suite)

Resolves opensearch-project/sql#5150