### PR TITLE
[BugFix] Fix silent integer overflow in arithmetic (#5164)

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLBuiltinOperators.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLBuiltinOperators.java
@@ -108,6 +108,7 @@ import org.opensearch.sql.expression.function.udf.math.DivideFunction;
 import org.opensearch.sql.expression.function.udf.math.EulerFunction;
 import org.opensearch.sql.expression.function.udf.math.ModFunction;
 import org.opensearch.sql.expression.function.udf.math.NumberToStringFunction;
+import org.opensearch.sql.expression.function.udf.math.SafeArithmeticFunction;
 import org.opensearch.sql.expression.function.udf.math.ScalarMaxFunction;
 import org.opensearch.sql.expression.function.udf.math.ScalarMinFunction;
 
@@ -141,6 +142,14 @@ public class PPLBuiltinOperators extends ReflectiveSqlOperatorTable {
   public static final SqlOperator CIDRMATCH = new CidrMatchFunction().toUDF("CIDRMATCH");
   public static final SqlOperator SCALAR_MAX = new ScalarMaxFunction().toUDF("SCALAR_MAX");
   public static final SqlOperator SCALAR_MIN = new ScalarMinFunction().toUDF("SCALAR_MIN");
+
+  // Safe arithmetic operators (overflow-checked)
+  public static final SqlOperator SAFE_ADD =
+      new SafeArithmeticFunction.SafeAddFunction().toUDF("SAFE_ADD");
+  public static final SqlOperator SAFE_SUBTRACT =
+      new SafeArithmeticFunction.SafeSubtractFunction().toUDF("SAFE_SUBTRACT");
+  public static final SqlOperator SAFE_MULTIPLY =
+      new SafeArithmeticFunction.SafeMultiplyFunction().toUDF("SAFE_MULTIPLY");
 
   public static final SqlOperator COSH =
       adaptMathFunctionToUDF(

--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
@@ -280,7 +280,6 @@ import org.apache.calcite.sql.fun.SqlLibraryOperators;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.fun.SqlTrimFunction.Flag;
 import org.apache.calcite.sql.type.CompositeOperandTypeChecker;
-import org.apache.calcite.sql.type.FamilyOperandTypeChecker;
 import org.apache.calcite.sql.type.ImplicitCastOperandTypeChecker;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.SameOperandTypeChecker;
@@ -726,23 +725,17 @@ public class PPLFuncImpTable {
       registerOperator(OR, SqlStdOperatorTable.OR);
       registerOperator(NOT, SqlStdOperatorTable.NOT);
 
-      // Register ADDFUNCTION for numeric addition only
-      registerOperator(ADDFUNCTION, SqlStdOperatorTable.PLUS);
-      registerOperator(
-          SUBTRACTFUNCTION,
-          SqlStdOperatorTable.MINUS,
-          PPLTypeChecker.wrapFamily((FamilyOperandTypeChecker) OperandTypes.NUMERIC_NUMERIC));
-      registerOperator(
-          SUBTRACT,
-          SqlStdOperatorTable.MINUS,
-          PPLTypeChecker.wrapFamily((FamilyOperandTypeChecker) OperandTypes.NUMERIC_NUMERIC));
+      // Register ADDFUNCTION for numeric addition only (overflow-safe)
+      registerOperator(ADDFUNCTION, PPLBuiltinOperators.SAFE_ADD);
+      registerOperator(SUBTRACTFUNCTION, PPLBuiltinOperators.SAFE_SUBTRACT);
+      registerOperator(SUBTRACT, PPLBuiltinOperators.SAFE_SUBTRACT);
       // Add DATETIME-DATETIME variant for timestamp binning support
       registerOperator(
           SUBTRACT,
           SqlStdOperatorTable.MINUS,
           PPLTypeChecker.family(SqlTypeFamily.DATETIME, SqlTypeFamily.DATETIME));
-      registerOperator(MULTIPLY, SqlStdOperatorTable.MULTIPLY);
-      registerOperator(MULTIPLYFUNCTION, SqlStdOperatorTable.MULTIPLY);
+      registerOperator(MULTIPLY, PPLBuiltinOperators.SAFE_MULTIPLY);
+      registerOperator(MULTIPLYFUNCTION, PPLBuiltinOperators.SAFE_MULTIPLY);
       registerOperator(TRUNCATE, SqlStdOperatorTable.TRUNCATE);
       registerOperator(ASCII, SqlStdOperatorTable.ASCII);
       registerOperator(LENGTH, SqlStdOperatorTable.CHAR_LENGTH);
@@ -1096,12 +1089,8 @@ public class PPLFuncImpTable {
           ADD,
           SqlStdOperatorTable.CONCAT,
           PPLTypeChecker.family(SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER));
-      // Register ADD (+ symbol) for numeric addition
-      // Replace type checker since PLUS also supports binary addition
-      registerOperator(
-          ADD,
-          SqlStdOperatorTable.PLUS,
-          PPLTypeChecker.family(SqlTypeFamily.NUMERIC, SqlTypeFamily.NUMERIC));
+      // Register ADD (+ symbol) for numeric addition (overflow-safe)
+      registerOperator(ADD, PPLBuiltinOperators.SAFE_ADD);
       // Replace with a custom CompositeOperandTypeChecker to check both operands as
       // SqlStdOperatorTable.ITEM.getOperandTypeChecker() checks only the first
       // operand instead

--- a/core/src/main/java/org/opensearch/sql/expression/function/udf/math/SafeArithmeticFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/udf/math/SafeArithmeticFunction.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.expression.function.udf.math;
+
+import java.math.BigDecimal;
+import java.util.List;
+import org.apache.calcite.adapter.enumerable.NotNullImplementor;
+import org.apache.calcite.adapter.enumerable.NullPolicy;
+import org.apache.calcite.adapter.enumerable.RexToLixTranslator;
+import org.apache.calcite.linq4j.tree.Expression;
+import org.apache.calcite.linq4j.tree.Expressions;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlReturnTypeInference;
+import org.apache.calcite.sql.type.SqlTypeTransforms;
+import org.opensearch.sql.calcite.utils.MathUtils;
+import org.opensearch.sql.calcite.utils.PPLOperandTypes;
+import org.opensearch.sql.expression.function.ImplementorUDF;
+import org.opensearch.sql.expression.function.UDFOperandMetadata;
+
+/**
+ * Safe arithmetic functions that throw ArithmeticException on integer/long overflow instead of
+ * silently wrapping. This applies to addition, subtraction, and multiplication of integral types.
+ */
+public class SafeArithmeticFunction {
+
+  /** Safe addition: uses Math.addExact for integral types to detect overflow. */
+  public static class SafeAddFunction extends ImplementorUDF {
+    public SafeAddFunction() {
+      super(new SafeAddImplementor(), NullPolicy.ANY);
+    }
+
+    @Override
+    public SqlReturnTypeInference getReturnTypeInference() {
+      return ReturnTypes.LEAST_RESTRICTIVE.andThen(SqlTypeTransforms.FORCE_NULLABLE);
+    }
+
+    @Override
+    public UDFOperandMetadata getOperandMetadata() {
+      return PPLOperandTypes.NUMERIC_NUMERIC;
+    }
+  }
+
+  /** Safe subtraction: uses Math.subtractExact for integral types to detect overflow. */
+  public static class SafeSubtractFunction extends ImplementorUDF {
+    public SafeSubtractFunction() {
+      super(new SafeSubtractImplementor(), NullPolicy.ANY);
+    }
+
+    @Override
+    public SqlReturnTypeInference getReturnTypeInference() {
+      return ReturnTypes.LEAST_RESTRICTIVE.andThen(SqlTypeTransforms.FORCE_NULLABLE);
+    }
+
+    @Override
+    public UDFOperandMetadata getOperandMetadata() {
+      return PPLOperandTypes.NUMERIC_NUMERIC;
+    }
+  }
+
+  /** Safe multiplication: uses Math.multiplyExact for integral types to detect overflow. */
+  public static class SafeMultiplyFunction extends ImplementorUDF {
+    public SafeMultiplyFunction() {
+      super(new SafeMultiplyImplementor(), NullPolicy.ANY);
+    }
+
+    @Override
+    public SqlReturnTypeInference getReturnTypeInference() {
+      return ReturnTypes.LEAST_RESTRICTIVE.andThen(SqlTypeTransforms.FORCE_NULLABLE);
+    }
+
+    @Override
+    public UDFOperandMetadata getOperandMetadata() {
+      return PPLOperandTypes.NUMERIC_NUMERIC;
+    }
+  }
+
+  /**
+   * Helper to perform overflow-safe coercion back to the widest integral type. If both operands are
+   * int-width or narrower, the result must fit in an int.
+   */
+  static Number safeCoerceToWidestIntegralType(Number a, Number b, long value) {
+    if (a instanceof Long || b instanceof Long) {
+      return value;
+    } else if (a instanceof Integer || b instanceof Integer) {
+      // Verify result fits in int range
+      if (value < Integer.MIN_VALUE || value > Integer.MAX_VALUE) {
+        throw new ArithmeticException("integer overflow");
+      }
+      return (int) value;
+    } else if (a instanceof Short || b instanceof Short) {
+      if (value < Short.MIN_VALUE || value > Short.MAX_VALUE) {
+        throw new ArithmeticException("short overflow");
+      }
+      return (short) value;
+    } else {
+      if (value < Byte.MIN_VALUE || value > Byte.MAX_VALUE) {
+        throw new ArithmeticException("byte overflow");
+      }
+      return (byte) value;
+    }
+  }
+
+  /** Implementor for safe addition. */
+  public static class SafeAddImplementor implements NotNullImplementor {
+    @Override
+    public Expression implement(
+        RexToLixTranslator translator, RexCall call, List<Expression> translatedOperands) {
+      return Expressions.call(
+          SafeAddImplementor.class,
+          "safeAdd",
+          Expressions.convert_(Expressions.box(translatedOperands.get(0)), Number.class),
+          Expressions.convert_(Expressions.box(translatedOperands.get(1)), Number.class));
+    }
+
+    /** Performs overflow-safe addition. */
+    public static Number safeAdd(Number a, Number b) {
+      if (MathUtils.isIntegral(a) && MathUtils.isIntegral(b)) {
+        long result = Math.addExact(a.longValue(), b.longValue());
+        return safeCoerceToWidestIntegralType(a, b, result);
+      } else if (MathUtils.isDecimal(a) || MathUtils.isDecimal(b)) {
+        BigDecimal bd1 =
+            a instanceof BigDecimal ? (BigDecimal) a : BigDecimal.valueOf(a.doubleValue());
+        BigDecimal bd2 =
+            b instanceof BigDecimal ? (BigDecimal) b : BigDecimal.valueOf(b.doubleValue());
+        return bd1.add(bd2);
+      }
+      double result = a.doubleValue() + b.doubleValue();
+      return MathUtils.coerceToWidestFloatingType(a, b, result);
+    }
+  }
+
+  /** Implementor for safe subtraction. */
+  public static class SafeSubtractImplementor implements NotNullImplementor {
+    @Override
+    public Expression implement(
+        RexToLixTranslator translator, RexCall call, List<Expression> translatedOperands) {
+      return Expressions.call(
+          SafeSubtractImplementor.class,
+          "safeSubtract",
+          Expressions.convert_(Expressions.box(translatedOperands.get(0)), Number.class),
+          Expressions.convert_(Expressions.box(translatedOperands.get(1)), Number.class));
+    }
+
+    /** Performs overflow-safe subtraction. */
+    public static Number safeSubtract(Number a, Number b) {
+      if (MathUtils.isIntegral(a) && MathUtils.isIntegral(b)) {
+        long result = Math.subtractExact(a.longValue(), b.longValue());
+        return safeCoerceToWidestIntegralType(a, b, result);
+      } else if (MathUtils.isDecimal(a) || MathUtils.isDecimal(b)) {
+        BigDecimal bd1 =
+            a instanceof BigDecimal ? (BigDecimal) a : BigDecimal.valueOf(a.doubleValue());
+        BigDecimal bd2 =
+            b instanceof BigDecimal ? (BigDecimal) b : BigDecimal.valueOf(b.doubleValue());
+        return bd1.subtract(bd2);
+      }
+      double result = a.doubleValue() - b.doubleValue();
+      return MathUtils.coerceToWidestFloatingType(a, b, result);
+    }
+  }
+
+  /** Implementor for safe multiplication. */
+  public static class SafeMultiplyImplementor implements NotNullImplementor {
+    @Override
+    public Expression implement(
+        RexToLixTranslator translator, RexCall call, List<Expression> translatedOperands) {
+      return Expressions.call(
+          SafeMultiplyImplementor.class,
+          "safeMultiply",
+          Expressions.convert_(Expressions.box(translatedOperands.get(0)), Number.class),
+          Expressions.convert_(Expressions.box(translatedOperands.get(1)), Number.class));
+    }
+
+    /** Performs overflow-safe multiplication. */
+    public static Number safeMultiply(Number a, Number b) {
+      if (MathUtils.isIntegral(a) && MathUtils.isIntegral(b)) {
+        long result = Math.multiplyExact(a.longValue(), b.longValue());
+        return safeCoerceToWidestIntegralType(a, b, result);
+      } else if (MathUtils.isDecimal(a) || MathUtils.isDecimal(b)) {
+        BigDecimal bd1 =
+            a instanceof BigDecimal ? (BigDecimal) a : BigDecimal.valueOf(a.doubleValue());
+        BigDecimal bd2 =
+            b instanceof BigDecimal ? (BigDecimal) b : BigDecimal.valueOf(b.doubleValue());
+        return bd1.multiply(bd2);
+      }
+      double result = a.doubleValue() * b.doubleValue();
+      return MathUtils.coerceToWidestFloatingType(a, b, result);
+    }
+  }
+}

--- a/core/src/test/java/org/opensearch/sql/expression/function/udf/math/SafeArithmeticFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/udf/math/SafeArithmeticFunctionTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.expression.function.udf.math;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.opensearch.sql.expression.function.udf.math.SafeArithmeticFunction.SafeAddImplementor;
+import org.opensearch.sql.expression.function.udf.math.SafeArithmeticFunction.SafeMultiplyImplementor;
+import org.opensearch.sql.expression.function.udf.math.SafeArithmeticFunction.SafeSubtractImplementor;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class SafeArithmeticFunctionTest {
+
+  // ==================== Addition Tests ====================
+
+  @Test
+  void safeAdd_integer_normal() {
+    Number result = SafeAddImplementor.safeAdd(10, 20);
+    assertEquals(30, result.intValue());
+  }
+
+  @Test
+  void safeAdd_integer_max_plus_one_overflows() {
+    assertThrows(ArithmeticException.class, () -> SafeAddImplementor.safeAdd(Integer.MAX_VALUE, 1));
+  }
+
+  @Test
+  void safeAdd_long_normal() {
+    Number result = SafeAddImplementor.safeAdd(10L, 20L);
+    assertEquals(30L, result.longValue());
+  }
+
+  @Test
+  void safeAdd_long_max_plus_one_overflows() {
+    assertThrows(ArithmeticException.class, () -> SafeAddImplementor.safeAdd(Long.MAX_VALUE, 1L));
+  }
+
+  @Test
+  void safeAdd_double_no_overflow() {
+    Number result = SafeAddImplementor.safeAdd(1.5, 2.5);
+    assertEquals(4.0, result.doubleValue(), 0.001);
+  }
+
+  @Test
+  void safeAdd_float_no_overflow() {
+    Number result = SafeAddImplementor.safeAdd(1.5f, 2.5f);
+    assertEquals(4.0f, result.floatValue(), 0.001);
+  }
+
+  @Test
+  void safeAdd_mixed_int_long_promotes_to_long() {
+    // int MAX + long 1 => should succeed as long (result fits in long)
+    Number result = SafeAddImplementor.safeAdd(Integer.MAX_VALUE, 1L);
+    assertEquals(2147483648L, result.longValue());
+    assertEquals(Long.class, result.getClass());
+  }
+
+  // ==================== Subtraction Tests ====================
+
+  @Test
+  void safeSubtract_integer_normal() {
+    Number result = SafeSubtractImplementor.safeSubtract(20, 10);
+    assertEquals(10, result.intValue());
+  }
+
+  @Test
+  void safeSubtract_integer_min_minus_one_overflows() {
+    assertThrows(
+        ArithmeticException.class,
+        () -> SafeSubtractImplementor.safeSubtract(Integer.MIN_VALUE, 1));
+  }
+
+  @Test
+  void safeSubtract_long_normal() {
+    Number result = SafeSubtractImplementor.safeSubtract(20L, 10L);
+    assertEquals(10L, result.longValue());
+  }
+
+  @Test
+  void safeSubtract_long_min_minus_one_overflows() {
+    assertThrows(
+        ArithmeticException.class, () -> SafeSubtractImplementor.safeSubtract(Long.MIN_VALUE, 1L));
+  }
+
+  @Test
+  void safeSubtract_double_no_overflow() {
+    Number result = SafeSubtractImplementor.safeSubtract(5.5, 2.5);
+    assertEquals(3.0, result.doubleValue(), 0.001);
+  }
+
+  // ==================== Multiplication Tests ====================
+
+  @Test
+  void safeMultiply_integer_normal() {
+    Number result = SafeMultiplyImplementor.safeMultiply(10, 20);
+    assertEquals(200, result.intValue());
+  }
+
+  @Test
+  void safeMultiply_integer_overflow_throws() {
+    assertThrows(
+        ArithmeticException.class,
+        () -> SafeMultiplyImplementor.safeMultiply(Integer.MAX_VALUE, 2));
+  }
+
+  @Test
+  void safeMultiply_long_normal() {
+    Number result = SafeMultiplyImplementor.safeMultiply(10L, 20L);
+    assertEquals(200L, result.longValue());
+  }
+
+  @Test
+  void safeMultiply_long_overflow_throws() {
+    assertThrows(
+        ArithmeticException.class, () -> SafeMultiplyImplementor.safeMultiply(Long.MAX_VALUE, 2L));
+  }
+
+  @Test
+  void safeMultiply_double_no_overflow() {
+    Number result = SafeMultiplyImplementor.safeMultiply(2.5, 3.0);
+    assertEquals(7.5, result.doubleValue(), 0.001);
+  }
+
+  // ==================== Type Coercion Tests ====================
+
+  @Test
+  void safeAdd_preserves_integer_type() {
+    Number result = SafeAddImplementor.safeAdd(1, 2);
+    assertEquals(Integer.class, result.getClass());
+  }
+
+  @Test
+  void safeAdd_preserves_long_type() {
+    Number result = SafeAddImplementor.safeAdd(1L, 2L);
+    assertEquals(Long.class, result.getClass());
+  }
+
+  @Test
+  void safeAdd_widens_int_to_long() {
+    Number result = SafeAddImplementor.safeAdd(1, 2L);
+    assertEquals(Long.class, result.getClass());
+  }
+
+  @Test
+  void safeAdd_preserves_double_type() {
+    Number result = SafeAddImplementor.safeAdd(1.0, 2.0);
+    assertEquals(Double.class, result.getClass());
+  }
+
+  @Test
+  void safeAdd_preserves_float_type() {
+    Number result = SafeAddImplementor.safeAdd(1.0f, 2.0f);
+    assertEquals(Float.class, result.getClass());
+  }
+}

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLArithmeticOverflowIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLArithmeticOverflowIT.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.remote;
+
+import static org.opensearch.sql.util.MatcherUtils.rows;
+import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
+
+import java.io.IOException;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.opensearch.client.Request;
+import org.opensearch.client.ResponseException;
+import org.opensearch.sql.ppl.PPLIntegTestCase;
+
+public class CalcitePPLArithmeticOverflowIT extends PPLIntegTestCase {
+
+  private static final String TEST_INDEX = "test_arithmetic_overflow";
+
+  @Override
+  public void init() throws Exception {
+    super.init();
+    enableCalcite();
+
+    // Delete and recreate test index
+    try {
+      client().performRequest(new Request("DELETE", "/" + TEST_INDEX));
+    } catch (ResponseException e) {
+      // Index may not exist yet - ignore
+    }
+
+    // Create test index
+    Request createIndex = new Request("PUT", "/" + TEST_INDEX);
+    createIndex.setJsonEntity(
+        "{"
+            + "\"mappings\": {"
+            + "  \"properties\": {"
+            + "    \"int_field\": { \"type\": \"integer\" },"
+            + "    \"long_field\": { \"type\": \"long\" }"
+            + "  }"
+            + "}"
+            + "}");
+    client().performRequest(createIndex);
+
+    // Insert max value record
+    Request insert = new Request("PUT", "/" + TEST_INDEX + "/_doc/1?refresh=true");
+    insert.setJsonEntity(
+        "{" + "\"int_field\": 2147483647," + "\"long_field\": 9223372036854775807" + "}");
+    client().performRequest(insert);
+
+    // Insert normal record
+    Request insert2 = new Request("PUT", "/" + TEST_INDEX + "/_doc/2?refresh=true");
+    insert2.setJsonEntity("{" + "\"int_field\": 100," + "\"long_field\": 200" + "}");
+    client().performRequest(insert2);
+  }
+
+  @Test
+  public void testIntegerAdditionOverflowThrowsError() {
+    assertThrows(
+        ResponseException.class,
+        () ->
+            executeQuery(
+                String.format(
+                    "source=%s | where int_field = 2147483647 | eval overflow = int_field + 1"
+                        + " | fields int_field, overflow",
+                    TEST_INDEX)));
+  }
+
+  @Test
+  public void testLongAdditionOverflowThrowsError() {
+    assertThrows(
+        ResponseException.class,
+        () ->
+            executeQuery(
+                String.format(
+                    "source=%s | where long_field = 9223372036854775807 | eval overflow ="
+                        + " long_field + 1 | fields long_field, overflow",
+                    TEST_INDEX)));
+  }
+
+  @Test
+  public void testIntegerMultiplicationOverflowThrowsError() {
+    assertThrows(
+        ResponseException.class,
+        () ->
+            executeQuery(
+                String.format(
+                    "source=%s | where int_field = 2147483647 | eval overflow = int_field * 2"
+                        + " | fields int_field, overflow",
+                    TEST_INDEX)));
+  }
+
+  @Test
+  public void testNormalArithmeticStillWorks() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | where int_field = 100 | eval sum = int_field + 50, diff ="
+                    + " int_field - 50, prod = int_field * 2 | fields int_field, sum, diff, prod",
+                TEST_INDEX));
+    verifyDataRows(result, rows(100, 150, 50, 200));
+  }
+
+  @Test
+  public void testNormalLongArithmeticStillWorks() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | where long_field = 200 | eval sum = long_field + 100, diff ="
+                    + " long_field - 100, prod = long_field * 2 | fields long_field, sum, diff,"
+                    + " prod",
+                TEST_INDEX));
+    verifyDataRows(result, rows(200, 300, 100, 400));
+  }
+}

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/5164.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/5164.yml
@@ -1,0 +1,79 @@
+setup:
+  - skip:
+      features:
+        - headers
+        - allowed_warnings
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled: true
+  - do:
+      indices.create:
+        index: test_overflow
+        body:
+          mappings:
+            properties:
+              int_field:
+                type: integer
+              long_field:
+                type: long
+  - do:
+      bulk:
+        index: test_overflow
+        refresh: true
+        body:
+          - '{"index": {}}'
+          - '{"int_field": 2147483647, "long_field": 9223372036854775807}'
+          - '{"index": {}}'
+          - '{"int_field": 100, "long_field": 200}'
+
+---
+teardown:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled: false
+
+---
+"Normal integer addition works":
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: 'source=test_overflow | where int_field = 100 | eval sum = int_field + 50 | fields int_field, sum'
+  - match: {"total": 1}
+  - match: {"datarows": [[100, 150]]}
+
+---
+"Normal long addition works":
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: 'source=test_overflow | where long_field = 200 | eval sum = long_field + 100 | fields long_field, sum'
+  - match: {"total": 1}
+  - match: {"datarows": [[200, 300]]}
+
+---
+"Integer overflow throws error":
+  - do:
+      catch: /ArithmeticException|integer overflow/
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: 'source=test_overflow | where int_field = 2147483647 | eval overflow = int_field + 1 | fields int_field, overflow'
+
+---
+"Long overflow throws error":
+  - do:
+      catch: /ArithmeticException|integer overflow/
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: 'source=test_overflow | where long_field = 9223372036854775807 | eval overflow = long_field + 1 | fields long_field, overflow'


### PR DESCRIPTION
## Summary
- Replace Calcite's standard arithmetic operators (`SqlStdOperatorTable.PLUS`, `MINUS`, `MULTIPLY`) with custom overflow-safe UDF implementations
- New `SafeArithmeticFunction` uses `Math.addExact`, `Math.subtractExact`, and `Math.multiplyExact` for integral types to throw `ArithmeticException` on overflow instead of silently wrapping
- Floating-point and BigDecimal arithmetic remain unchanged (no overflow concept)

## Test plan
- [x] Unit tests in `SafeArithmeticFunctionTest` covering overflow detection for int/long add/subtract/multiply
- [x] Integration test in `CalcitePPLArithmeticOverflowIT` verifying overflow errors and normal arithmetic
- [x] YAML REST test in `issues/5164.yml` verifying overflow detection via REST API

Resolves opensearch-project/sql#5164