### PR TITLE
[BugFix] Fix bin/chart NPE with null values (#5174)

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
@@ -3205,7 +3205,7 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
         || node.getColumnSplit() == null
         || Objects.equals(config.limit, 0)) {
       // The output of chart is expected to be ordered by row split names
-      relBuilder.sort(relBuilder.field(0));
+      relBuilder.sort(relBuilder.nullsLast(relBuilder.field(0)));
       return relBuilder.peek();
     }
 
@@ -3275,7 +3275,8 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
                 relBuilder.field(2))
             .as(aggFieldName));
     // The output of chart is expected to be ordered by row and column split names
-    relBuilder.sort(relBuilder.field(0), relBuilder.field(1));
+    relBuilder.sort(
+        relBuilder.nullsLast(relBuilder.field(0)), relBuilder.nullsLast(relBuilder.field(1)));
     return relBuilder.peek();
   }
 

--- a/core/src/main/java/org/opensearch/sql/expression/function/udf/binning/MinspanBucketFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/udf/binning/MinspanBucketFunction.java
@@ -14,6 +14,7 @@ import org.apache.calcite.linq4j.tree.Expressions;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
+import org.apache.calcite.sql.type.SqlTypeTransforms;
 import org.opensearch.sql.calcite.utils.PPLOperandTypes;
 import org.opensearch.sql.expression.function.ImplementorUDF;
 import org.opensearch.sql.expression.function.UDFOperandMetadata;
@@ -43,7 +44,7 @@ public class MinspanBucketFunction extends ImplementorUDF {
 
   @Override
   public SqlReturnTypeInference getReturnTypeInference() {
-    return ReturnTypes.VARCHAR_2000;
+    return ReturnTypes.VARCHAR_2000.andThen(SqlTypeTransforms.FORCE_NULLABLE);
   }
 
   @Override

--- a/core/src/main/java/org/opensearch/sql/expression/function/udf/binning/RangeBucketFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/udf/binning/RangeBucketFunction.java
@@ -14,6 +14,7 @@ import org.apache.calcite.linq4j.tree.Expressions;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
+import org.apache.calcite.sql.type.SqlTypeTransforms;
 import org.opensearch.sql.calcite.utils.PPLOperandTypes;
 import org.opensearch.sql.expression.function.ImplementorUDF;
 import org.opensearch.sql.expression.function.UDFOperandMetadata;
@@ -47,7 +48,7 @@ public class RangeBucketFunction extends ImplementorUDF {
 
   @Override
   public SqlReturnTypeInference getReturnTypeInference() {
-    return ReturnTypes.VARCHAR_2000;
+    return ReturnTypes.VARCHAR_2000.andThen(SqlTypeTransforms.FORCE_NULLABLE);
   }
 
   @Override

--- a/core/src/main/java/org/opensearch/sql/expression/function/udf/binning/SpanBucketFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/udf/binning/SpanBucketFunction.java
@@ -14,6 +14,7 @@ import org.apache.calcite.linq4j.tree.Expressions;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
+import org.apache.calcite.sql.type.SqlTypeTransforms;
 import org.opensearch.sql.calcite.utils.PPLOperandTypes;
 import org.opensearch.sql.expression.function.ImplementorUDF;
 import org.opensearch.sql.expression.function.UDFOperandMetadata;
@@ -41,7 +42,7 @@ public class SpanBucketFunction extends ImplementorUDF {
 
   @Override
   public SqlReturnTypeInference getReturnTypeInference() {
-    return ReturnTypes.VARCHAR_2000;
+    return ReturnTypes.VARCHAR_2000.andThen(SqlTypeTransforms.FORCE_NULLABLE);
   }
 
   @Override

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteBinChartNullIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteBinChartNullIT.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.remote;
+
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK_WITH_NULL_VALUES;
+import static org.opensearch.sql.util.MatcherUtils.rows;
+import static org.opensearch.sql.util.MatcherUtils.schema;
+import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
+import static org.opensearch.sql.util.MatcherUtils.verifySchema;
+
+import java.io.IOException;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.opensearch.sql.ppl.PPLIntegTestCase;
+
+/** Integration test for GitHub issue #5174: bin/chart NPE with null values. */
+public class CalciteBinChartNullIT extends PPLIntegTestCase {
+  @Override
+  public void init() throws Exception {
+    super.init();
+    enableCalcite();
+    loadIndex(Index.BANK_WITH_NULL_VALUES);
+  }
+
+  @Test
+  public void testBinThenChartWithNullValuesShouldNotCauseNPE() throws IOException {
+    // bin balance span=10000 produces null for documents without a balance field.
+    // chart count() over bal_bin by gender should handle these null bin values safely.
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | bin balance span=10000 as bal_bin"
+                    + " | chart count() over bal_bin by gender",
+                TEST_INDEX_BANK_WITH_NULL_VALUES));
+    verifySchema(
+        result,
+        schema("bal_bin", "string"),
+        schema("gender", "string"),
+        schema("count()", "bigint"));
+    // Should only contain rows for non-null balance values (4 records with balance)
+    verifyDataRows(
+        result,
+        rows("0-10000", "M", 1),
+        rows("30000-40000", "F", 1),
+        rows("30000-40000", "M", 1),
+        rows("40000-50000", "F", 1));
+  }
+
+  @Test
+  public void testBinThenChartSingleGroupWithNullValues() throws IOException {
+    // chart with only row split (no column split): the simpler sort path
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | bin balance span=10000 as bal_bin | chart count() over bal_bin",
+                TEST_INDEX_BANK_WITH_NULL_VALUES));
+    verifySchema(result, schema("bal_bin", "string"), schema("count()", "bigint"));
+    verifyDataRows(result, rows("0-10000", 1), rows("30000-40000", 2), rows("40000-50000", 1));
+  }
+}

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/DataTypeIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/DataTypeIT.java
@@ -146,6 +146,47 @@ public class DataTypeIT extends PPLIntegTestCase {
   }
 
   @Test
+  public void testBooleanFieldFromNumberAcrossWildcardIndices() throws Exception {
+    // Reproduce issue #5269: querying across indices where same field has conflicting types
+    // (boolean vs text) and the text-typed index stores a numeric value like 0.
+    String indexBool = "repro_bool_test_bb";
+    String indexText = "repro_bool_test_aa";
+
+    try {
+      // Create index with boolean mapping
+      Request createBool = new Request("PUT", "/" + indexBool);
+      createBool.setJsonEntity(
+          "{\"mappings\":{\"properties\":{\"flag\":{\"type\":\"boolean\"},"
+              + "\"startTime\":{\"type\":\"date_nanos\"}}}}");
+      client().performRequest(createBool);
+
+      // Create index with text mapping
+      Request createText = new Request("PUT", "/" + indexText);
+      createText.setJsonEntity(
+          "{\"mappings\":{\"properties\":{\"flag\":{\"type\":\"text\"},"
+              + "\"startTime\":{\"type\":\"date_nanos\"}}}}");
+      client().performRequest(createText);
+
+      // Insert boolean value into boolean-typed index
+      Request insertBool = new Request("PUT", "/" + indexBool + "/_doc/1?refresh=true");
+      insertBool.setJsonEntity("{\"startTime\":\"2026-03-25T20:25:00.000Z\",\"flag\":false}");
+      client().performRequest(insertBool);
+
+      // Insert numeric value into text-typed index
+      Request insertText = new Request("PUT", "/" + indexText + "/_doc/1?refresh=true");
+      insertText.setJsonEntity("{\"startTime\":\"2026-03-24T20:25:00.000Z\",\"flag\":0}");
+      client().performRequest(insertText);
+
+      // Query across both indices with wildcard — should not throw an error
+      JSONObject result = executeQuery("source=repro_bool_test_* | fields flag");
+      assertEquals(2, result.getJSONArray("datarows").length());
+    } finally {
+      client().performRequest(new Request("DELETE", "/" + indexBool));
+      client().performRequest(new Request("DELETE", "/" + indexText));
+    }
+  }
+
+  @Test
   public void testBooleanFieldFromString() throws Exception {
     final int docId = 2;
     Request insertRequest =

--- a/integ-test/src/test/resources/bounty_numbers.json
+++ b/integ-test/src/test/resources/bounty_numbers.json
@@ -1,0 +1,8 @@
+{"index":{"_id":"1"}}
+{"count":1,"category":"A","subcategory":"X","value":10.5,"ts":"2024-01-01"}
+{"index":{"_id":"2"}}
+{"count":2,"category":"A","subcategory":"Y","value":20.3,"ts":"2024-01-02"}
+{"index":{"_id":"3"}}
+{"count":10,"category":"B","subcategory":"X","value":100.0,"ts":"2024-01-03"}
+{"index":{"_id":"4"}}
+{"count":null,"category":"B","subcategory":"Y","value":null,"ts":"2024-01-04"}

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/5174.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/5174.yml
@@ -1,0 +1,81 @@
+setup:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled: true
+
+  - do:
+      indices.create:
+        index: issue5174
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+          mappings:
+            properties:
+              count:
+                type: integer
+              category:
+                type: keyword
+              subcategory:
+                type: keyword
+              value:
+                type: double
+              ts:
+                type: date
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "issue5174", "_id": "1"}}'
+          - '{"count": 1, "category": "A", "subcategory": "X", "value": 10.5, "ts": "2024-01-01"}'
+          - '{"index": {"_index": "issue5174", "_id": "2"}}'
+          - '{"count": 2, "category": "A", "subcategory": "Y", "value": 20.3, "ts": "2024-01-02"}'
+          - '{"index": {"_index": "issue5174", "_id": "3"}}'
+          - '{"count": 10, "category": "B", "subcategory": "X", "value": 100.0, "ts": "2024-01-03"}'
+          - '{"index": {"_index": "issue5174", "_id": "4"}}'
+          - '{"count": null, "category": "B", "subcategory": "Y", "value": null, "ts": "2024-01-04"}'
+
+---
+teardown:
+  - do:
+      indices.delete:
+        index: issue5174
+        ignore_unavailable: true
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled: false
+
+---
+"Issue 5174: bin then chart with null values should not cause NPE":
+  - skip:
+      features:
+        - headers
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: source=issue5174 | bin value span=50 as val_bin | chart count() over val_bin by category
+
+  - match: { total: 3 }
+  - match: { schema: [ { name: val_bin, type: string }, { name: category, type: string }, { name: "count()", type: bigint } ] }
+
+---
+"Issue 5174: bin then chart with single group and null values":
+  - skip:
+      features:
+        - headers
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: source=issue5174 | bin value span=50 as val_bin | chart count() over val_bin
+
+  - match: { total: 2 }
+  - match: { schema: [ { name: val_bin, type: string }, { name: "count()", type: bigint } ] }

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/5269.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/5269.yml
@@ -1,0 +1,63 @@
+setup:
+  - do:
+      indices.create:
+        index: issue5269_bool
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+          mappings:
+            properties:
+              flag:
+                type: boolean
+              startTime:
+                type: date_nanos
+
+  - do:
+      indices.create:
+        index: issue5269_text
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+          mappings:
+            properties:
+              flag:
+                type: text
+              startTime:
+                type: date_nanos
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "issue5269_bool", "_id": "1"}}'
+          - '{"startTime": "2026-03-25T20:25:00.000Z", "flag": false}'
+          - '{"index": {"_index": "issue5269_text", "_id": "1"}}'
+          - '{"startTime": "2026-03-24T20:25:00.000Z", "flag": 0}'
+
+---
+teardown:
+  - do:
+      indices.delete:
+        index: issue5269_bool
+        ignore_unavailable: true
+  - do:
+      indices.delete:
+        index: issue5269_text
+        ignore_unavailable: true
+
+---
+"Issue 5269: PPL wildcard query across indices with boolean/text mapping conflict should not error":
+  - skip:
+      features:
+        - headers
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: source=issue5269_* | fields flag
+
+  - match: { total: 2 }
+  - length: { datarows: 2 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/utils/OpenSearchJsonContent.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/utils/OpenSearchJsonContent.java
@@ -212,6 +212,8 @@ public class OpenSearchJsonContent implements Content {
       return node.booleanValue();
     } else if (node.isTextual()) {
       return Boolean.parseBoolean(node.textValue());
+    } else if (node.isNumber()) {
+      return node.intValue() != 0;
     } else {
       if (LOG.isDebugEnabled()) {
         LOG.debug("node '{}' must be a boolean", node);

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactoryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactoryTest.java
@@ -234,6 +234,9 @@ class OpenSearchExprValueFactoryTest {
   public void constructBoolean() {
     assertAll(
         () -> assertEquals(booleanValue(true), tupleValue("{\"boolV\":true}").get("boolV")),
+        () -> assertEquals(booleanValue(false), tupleValue("{\"boolV\":false}").get("boolV")),
+        () -> assertEquals(booleanValue(true), tupleValue("{\"boolV\":1}").get("boolV")),
+        () -> assertEquals(booleanValue(false), tupleValue("{\"boolV\":0}").get("boolV")),
         () -> assertEquals(booleanValue(true), constructFromObject("boolV", true)),
         () -> assertEquals(booleanValue(true), constructFromObject("boolV", "true")),
         () -> assertEquals(booleanValue(true), constructFromObject("boolV", 1)),

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLChartNullTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLChartNullTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ppl.calcite;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.apache.calcite.DataContext;
+import org.apache.calcite.config.CalciteConnectionConfig;
+import org.apache.calcite.linq4j.Enumerable;
+import org.apache.calcite.linq4j.Linq4j;
+import org.apache.calcite.plan.RelTraitDef;
+import org.apache.calcite.rel.RelCollations;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelProtoDataType;
+import org.apache.calcite.schema.ScannableTable;
+import org.apache.calcite.schema.Schema;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.Statistic;
+import org.apache.calcite.schema.Statistics;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.test.CalciteAssert;
+import org.apache.calcite.tools.Frameworks;
+import org.apache.calcite.tools.Programs;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.junit.Test;
+
+/**
+ * Unit test for GitHub issue #5174: bin/chart NPE with null values.
+ *
+ * <p>Verifies that the chart command generates correct logical plans when the input contains null
+ * values from binning, and that the sort operations properly handle nulls.
+ */
+public class CalcitePPLChartNullTest extends CalcitePPLAbstractTest {
+
+  public CalcitePPLChartNullTest() {
+    super(CalciteAssert.SchemaSpec.SCOTT_WITH_TEMPORAL);
+  }
+
+  @Override
+  protected Frameworks.ConfigBuilder config(CalciteAssert.SchemaSpec... schemaSpecs) {
+    final SchemaPlus rootSchema = Frameworks.createRootSchema(true);
+    final SchemaPlus schema = CalciteAssert.addSchema(rootSchema, schemaSpecs);
+    // Table with null values matching the issue's bounty-numbers schema
+    ImmutableList<Object[]> rows =
+        ImmutableList.of(
+            new Object[] {1, "A", "X", 10.5},
+            new Object[] {2, "A", "Y", 20.3},
+            new Object[] {10, "B", "X", 100.0},
+            new Object[] {null, "B", "Y", null});
+    schema.add("bounty_numbers", new BountyNumbersTable(rows));
+    return Frameworks.newConfigBuilder()
+        .parserConfig(SqlParser.Config.DEFAULT)
+        .defaultSchema(schema)
+        .traitDefs((List<RelTraitDef>) null)
+        .programs(Programs.heuristicJoinOrder(Programs.RULE_SET, true, 2));
+  }
+
+  @Test
+  public void testBinThenChartWithNullValuesLogicalPlan() {
+    String ppl =
+        "source=bounty_numbers | bin value span=50 as val_bin"
+            + " | chart count() over val_bin by category";
+    RelNode root = getRelNode(ppl);
+    // Verify the SQL plan contains WHERE val_bin IS NOT NULL to filter null bin values,
+    // and NULLS LAST in ORDER BY for proper null handling in sort
+    String expectedSparkSql =
+        "SELECT `t2`.`val_bin`, CASE WHEN `t2`.`category` IS NULL THEN 'NULL' WHEN"
+            + " `t10`.`_row_number_chart_` <= 10 THEN `t2`.`category` ELSE 'OTHER' END"
+            + " `category`, SUM(`t2`.`count()`) `count()`\n"
+            + "FROM (SELECT `val_bin`, `category`, COUNT(*) `count()`\n"
+            + "FROM (SELECT `count`, `category`, `subcategory`, `value`,"
+            + " SPAN_BUCKET(`value`, 50) `val_bin`\n"
+            + "FROM `scott`.`bounty_numbers`) `t`\n"
+            + "WHERE `val_bin` IS NOT NULL\n"
+            + "GROUP BY `val_bin`, `category`) `t2`\n"
+            + "LEFT JOIN (SELECT `category`, SUM(`count()`) `__grand_total__`, ROW_NUMBER() OVER"
+            + " (ORDER BY SUM(`count()`) DESC) `_row_number_chart_`\n"
+            + "FROM (SELECT `category`, COUNT(*) `count()`\n"
+            + "FROM (SELECT `count`, `category`, `subcategory`, `value`,"
+            + " SPAN_BUCKET(`value`, 50) `val_bin`\n"
+            + "FROM `scott`.`bounty_numbers`) `t3`\n"
+            + "WHERE `val_bin` IS NOT NULL\n"
+            + "GROUP BY `val_bin`, `category`) `t7`\n"
+            + "WHERE `category` IS NOT NULL\n"
+            + "GROUP BY `category`) `t10` ON `t2`.`category` = `t10`.`category`\n"
+            + "GROUP BY `t2`.`val_bin`, CASE WHEN `t2`.`category` IS NULL THEN 'NULL' WHEN"
+            + " `t10`.`_row_number_chart_` <= 10 THEN `t2`.`category` ELSE 'OTHER' END\n"
+            + "ORDER BY `t2`.`val_bin` NULLS LAST, 2 NULLS LAST";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testBinThenChartSingleGroupWithNullValuesLogicalPlan() {
+    String ppl =
+        "source=bounty_numbers | bin value span=50 as val_bin | chart count() over val_bin";
+    RelNode root = getRelNode(ppl);
+    // Verify null bin values are filtered and sort uses NULLS LAST
+    String expectedSparkSql =
+        "SELECT `val_bin`, COUNT(*) `count()`\n"
+            + "FROM (SELECT `count`, `category`, `subcategory`, `value`,"
+            + " SPAN_BUCKET(`value`, 50) `val_bin`\n"
+            + "FROM `scott`.`bounty_numbers`) `t`\n"
+            + "WHERE `val_bin` IS NOT NULL\n"
+            + "GROUP BY `val_bin`\n"
+            + "ORDER BY `val_bin` NULLS LAST";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @RequiredArgsConstructor
+  public static class BountyNumbersTable implements ScannableTable {
+    private final ImmutableList<Object[]> rows;
+
+    protected final RelProtoDataType protoRowType =
+        factory ->
+            factory
+                .builder()
+                .add("count", SqlTypeName.INTEGER)
+                .nullable(true)
+                .add("category", SqlTypeName.VARCHAR)
+                .nullable(true)
+                .add("subcategory", SqlTypeName.VARCHAR)
+                .nullable(true)
+                .add("value", SqlTypeName.DOUBLE)
+                .nullable(true)
+                .build();
+
+    @Override
+    public Enumerable<@Nullable Object[]> scan(DataContext root) {
+      return Linq4j.asEnumerable(rows);
+    }
+
+    @Override
+    public RelDataType getRowType(RelDataTypeFactory typeFactory) {
+      return protoRowType.apply(typeFactory);
+    }
+
+    @Override
+    public Statistic getStatistic() {
+      return Statistics.of(0d, ImmutableList.of(), RelCollations.createSingleton(0));
+    }
+
+    @Override
+    public Schema.TableType getJdbcTableType() {
+      return Schema.TableType.TABLE;
+    }
+
+    @Override
+    public boolean isRolledUp(String column) {
+      return false;
+    }
+
+    @Override
+    public boolean rolledUpColumnValidInsideAgg(
+        String column,
+        SqlCall call,
+        @Nullable SqlNode parent,
+        @Nullable CalciteConnectionConfig config) {
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Fix NullPointerException when using `bin` then `chart` with null values in the binned field
- Root cause: bin bucket functions (SpanBucketFunction, MinspanBucketFunction, RangeBucketFunction) declared non-nullable VARCHAR return type, causing Calcite to optimize away IS NOT NULL filters, allowing null group keys to reach Enumerable aggregation's TreeMap which crashes in compareTo
- Fix: declare return type as nullable using `FORCE_NULLABLE` so null-filtering in visitAggregation works correctly
- Also add `nullsLast` to chart command sorts as a defensive measure

Resolves opensearch-project/sql#5174

## Test plan

- [x] Unit test (CalcitePPLChartNullTest) verifying logical plan includes null filter
- [x] Integration test (CalciteBinChartNullIT) verifying bin+chart with null values works end-to-end
- [x] YAML REST test (5174.yml) reproducing the exact scenario from the issue
- [x] Existing chart and bin tests pass without regressions