### PR TITLE
[BugFix] Fix dedup aggregation pushdown nullifying renamed fields (#5150)

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLDedupIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLDedupIT.java
@@ -297,6 +297,38 @@ public class CalcitePPLDedupIT extends PPLIntegTestCase {
         rows("Z", 1, "D"));
   }
 
+  /**
+   * Test rename then dedup on a different field. Renamed field should retain original values. See
+   * https://github.com/opensearch-project/sql/issues/5150
+   */
+  @Test
+  public void testRenameThenDedupOnDifferentField() throws IOException {
+    // rename name as n, then dedup on category -- n should NOT be null
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | rename name as n | dedup category | fields category, n",
+                TEST_INDEX_DUPLICATION_NULLABLE));
+    verifySchema(actual, schema("category", null, "string"), schema("n", null, "string"));
+    verifyDataRows(actual, rows("X", "A"), rows("Y", "A"), rows("Z", "B"));
+  }
+
+  /**
+   * Test rename multiple fields then dedup on a different field. All renamed fields should retain
+   * values. See https://github.com/opensearch-project/sql/issues/5150
+   */
+  @Test
+  public void testRenameMultipleThenDedupOnDifferentField() throws IOException {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | rename name as n, category as cat | dedup n | fields n, cat",
+                TEST_INDEX_DUPLICATION_NULLABLE));
+    verifySchema(actual, schema("n", null, "string"), schema("cat", null, "string"));
+    verifyDataRows(
+        actual, rows("A", "X"), rows("B", "Z"), rows("C", "X"), rows("D", "Z"), rows("E", null));
+  }
+
   @Test
   public void testDedupExpr() throws IOException {
     JSONObject actual =

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/DataTypeIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/DataTypeIT.java
@@ -146,6 +146,47 @@ public class DataTypeIT extends PPLIntegTestCase {
   }
 
   @Test
+  public void testBooleanFieldFromNumberAcrossWildcardIndices() throws Exception {
+    // Reproduce issue #5269: querying across indices where same field has conflicting types
+    // (boolean vs text) and the text-typed index stores a numeric value like 0.
+    String indexBool = "repro_bool_test_bb";
+    String indexText = "repro_bool_test_aa";
+
+    try {
+      // Create index with boolean mapping
+      Request createBool = new Request("PUT", "/" + indexBool);
+      createBool.setJsonEntity(
+          "{\"mappings\":{\"properties\":{\"flag\":{\"type\":\"boolean\"},"
+              + "\"startTime\":{\"type\":\"date_nanos\"}}}}");
+      client().performRequest(createBool);
+
+      // Create index with text mapping
+      Request createText = new Request("PUT", "/" + indexText);
+      createText.setJsonEntity(
+          "{\"mappings\":{\"properties\":{\"flag\":{\"type\":\"text\"},"
+              + "\"startTime\":{\"type\":\"date_nanos\"}}}}");
+      client().performRequest(createText);
+
+      // Insert boolean value into boolean-typed index
+      Request insertBool = new Request("PUT", "/" + indexBool + "/_doc/1?refresh=true");
+      insertBool.setJsonEntity("{\"startTime\":\"2026-03-25T20:25:00.000Z\",\"flag\":false}");
+      client().performRequest(insertBool);
+
+      // Insert numeric value into text-typed index
+      Request insertText = new Request("PUT", "/" + indexText + "/_doc/1?refresh=true");
+      insertText.setJsonEntity("{\"startTime\":\"2026-03-24T20:25:00.000Z\",\"flag\":0}");
+      client().performRequest(insertText);
+
+      // Query across both indices with wildcard — should not throw an error
+      JSONObject result = executeQuery("source=repro_bool_test_* | fields flag");
+      assertEquals(2, result.getJSONArray("datarows").length());
+    } finally {
+      client().performRequest(new Request("DELETE", "/" + indexBool));
+      client().performRequest(new Request("DELETE", "/" + indexText));
+    }
+  }
+
+  @Test
   public void testBooleanFieldFromString() throws Exception {
     final int docId = 2;
     Request insertRequest =

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/5150.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/5150.yml
@@ -1,0 +1,101 @@
+setup:
+  - do:
+      indices.create:
+        index: test_issue_5150
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+          mappings:
+            properties:
+              count: { type: integer }
+              category: { type: keyword }
+              subcategory: { type: keyword }
+              value: { type: double }
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled: true
+
+---
+teardown:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled: false
+
+---
+"5150: Rename then dedup on different field should preserve renamed values":
+  - skip:
+      features:
+        - headers
+        - allowed_warnings
+  - do:
+      bulk:
+        index: test_issue_5150
+        refresh: true
+        body:
+          - '{"index": {}}'
+          - '{"count":1,"category":"A","subcategory":"X","value":10.5}'
+          - '{"index": {}}'
+          - '{"count":2,"category":"A","subcategory":"Y","value":20.3}'
+          - '{"index": {}}'
+          - '{"count":10,"category":"B","subcategory":"X","value":100.0}'
+          - '{"index": {}}'
+          - '{"count":5,"category":"C","subcategory":"Z","value":50.0}'
+  - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: source=test_issue_5150 | rename value as val | dedup category | fields category, val | sort category
+  - match: { total: 3 }
+  - length: { datarows: 3 }
+  # Verify val is not null (the bug would produce null for all val values)
+  - match: { datarows.0.0: "A" }
+  - is_true: datarows.0.1
+  - match: { datarows.1.0: "B" }
+  - is_true: datarows.1.1
+  - match: { datarows.2.0: "C" }
+  - is_true: datarows.2.1
+
+---
+"5150: Multiple renames then dedup should preserve all renamed values":
+  - skip:
+      features:
+        - headers
+        - allowed_warnings
+  - do:
+      bulk:
+        index: test_issue_5150
+        refresh: true
+        body:
+          - '{"index": {}}'
+          - '{"count":1,"category":"A","subcategory":"X","value":10.5}'
+          - '{"index": {}}'
+          - '{"count":2,"category":"A","subcategory":"Y","value":20.3}'
+          - '{"index": {}}'
+          - '{"count":10,"category":"B","subcategory":"X","value":100.0}'
+          - '{"index": {}}'
+          - '{"count":5,"category":"C","subcategory":"Z","value":50.0}'
+  - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: source=test_issue_5150 | rename value as val, category as cat | dedup cat | fields cat, val | sort cat
+  - match: { total: 3 }
+  - length: { datarows: 3 }
+  # Verify both renamed fields have values
+  - match: { datarows.0.0: "A" }
+  - is_true: datarows.0.1
+  - match: { datarows.1.0: "B" }
+  - is_true: datarows.1.1
+  - match: { datarows.2.0: "C" }
+  - is_true: datarows.2.1

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/5269.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/5269.yml
@@ -1,0 +1,63 @@
+setup:
+  - do:
+      indices.create:
+        index: issue5269_bool
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+          mappings:
+            properties:
+              flag:
+                type: boolean
+              startTime:
+                type: date_nanos
+
+  - do:
+      indices.create:
+        index: issue5269_text
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+          mappings:
+            properties:
+              flag:
+                type: text
+              startTime:
+                type: date_nanos
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "issue5269_bool", "_id": "1"}}'
+          - '{"startTime": "2026-03-25T20:25:00.000Z", "flag": false}'
+          - '{"index": {"_index": "issue5269_text", "_id": "1"}}'
+          - '{"startTime": "2026-03-24T20:25:00.000Z", "flag": 0}'
+
+---
+teardown:
+  - do:
+      indices.delete:
+        index: issue5269_bool
+        ignore_unavailable: true
+  - do:
+      indices.delete:
+        index: issue5269_text
+        ignore_unavailable: true
+
+---
+"Issue 5269: PPL wildcard query across indices with boolean/text mapping conflict should not error":
+  - skip:
+      features:
+        - headers
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: source=issue5269_* | fields flag
+
+  - match: { total: 2 }
+  - length: { datarows: 2 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/utils/OpenSearchJsonContent.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/utils/OpenSearchJsonContent.java
@@ -212,6 +212,8 @@ public class OpenSearchJsonContent implements Content {
       return node.booleanValue();
     } else if (node.isTextual()) {
       return Boolean.parseBoolean(node.textValue());
+    } else if (node.isNumber()) {
+      return node.intValue() != 0;
     } else {
       if (LOG.isDebugEnabled()) {
         LOG.debug("node '{}' must be a boolean", node);

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/request/AggregateAnalyzer.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/request/AggregateAnalyzer.java
@@ -38,6 +38,7 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -601,7 +602,24 @@ public class AggregateAnalyzer {
         TopHitsAggregationBuilder topHitsAggregationBuilder =
             createTopHitsBuilder(
                 aggCall, args, aggName, helper, dedupNumber, false, false, null, null);
-        yield Pair.of(topHitsAggregationBuilder, new TopHitsParser(aggName, false, false));
+        // Build rename mapping for fields whose project name differs from the original
+        // index field name. This is needed because the top_hits response uses original
+        // field names from _source, but the enumerator expects the renamed names from the
+        // logical plan's rowType. See https://github.com/opensearch-project/sql/issues/5150
+        Map<String, String> fieldRenameMapping = new HashMap<>();
+        args.stream()
+            .filter(rex -> rex.getKey() instanceof RexInputRef)
+            .forEach(
+                rex -> {
+                  String originalName = helper.inferNamedField(rex.getKey()).getRootName();
+                  String renamedName = rex.getValue();
+                  if (!originalName.equals(renamedName)) {
+                    fieldRenameMapping.put(originalName, renamedName);
+                  }
+                });
+        yield Pair.of(
+            topHitsAggregationBuilder,
+            new TopHitsParser(aggName, false, false, fieldRenameMapping));
       }
       default ->
           throw new AggregateAnalyzer.AggregateAnalyzerException(

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/response/agg/TopHitsParser.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/response/agg/TopHitsParser.java
@@ -27,10 +27,26 @@ public class TopHitsParser implements MetricParser {
   private final boolean returnSingleValue;
   private final boolean returnMergeValue;
 
+  /**
+   * Mapping from original index field name to renamed field name. Used when dedup pushdown fetches
+   * fields by their original index names but the enumerator expects the renamed names from the
+   * logical plan's rowType. Empty map means no renaming needed.
+   */
+  private final Map<String, String> fieldRenameMapping;
+
   public TopHitsParser(String name, boolean returnSingleValue, boolean returnMergeValue) {
+    this(name, returnSingleValue, returnMergeValue, Collections.emptyMap());
+  }
+
+  public TopHitsParser(
+      String name,
+      boolean returnSingleValue,
+      boolean returnMergeValue,
+      Map<String, String> fieldRenameMapping) {
     this.name = name;
     this.returnSingleValue = returnSingleValue;
     this.returnMergeValue = returnMergeValue;
+    this.fieldRenameMapping = fieldRenameMapping;
   }
 
   @Override
@@ -129,7 +145,7 @@ public class TopHitsParser implements MetricParser {
                         ? new LinkedHashMap<>()
                         : new LinkedHashMap<>(hit.getSourceAsMap());
                 hit.getFields().values().forEach(f -> map.put(f.getName(), f.getValue()));
-                return map;
+                return applyFieldRenameMapping(map);
               })
           .toList();
     }
@@ -145,6 +161,22 @@ public class TopHitsParser implements MetricParser {
 
   private boolean isSourceEmpty(SearchHit[] hits) {
     return hits[0].getSourceAsMap() == null || hits[0].getSourceAsMap().isEmpty();
+  }
+
+  /**
+   * Apply field rename mapping to a result map. Keys that appear in the rename mapping are replaced
+   * with the renamed name so the enumerator can resolve them correctly.
+   */
+  private Map<String, Object> applyFieldRenameMapping(Map<String, Object> map) {
+    if (fieldRenameMapping.isEmpty()) {
+      return map;
+    }
+    Map<String, Object> renamed = new LinkedHashMap<>();
+    for (Map.Entry<String, Object> entry : map.entrySet()) {
+      String key = fieldRenameMapping.getOrDefault(entry.getKey(), entry.getKey());
+      renamed.put(key, entry.getValue());
+    }
+    return renamed;
   }
 
   private Object getLeafValue(Object object) {

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactoryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactoryTest.java
@@ -234,6 +234,9 @@ class OpenSearchExprValueFactoryTest {
   public void constructBoolean() {
     assertAll(
         () -> assertEquals(booleanValue(true), tupleValue("{\"boolV\":true}").get("boolV")),
+        () -> assertEquals(booleanValue(false), tupleValue("{\"boolV\":false}").get("boolV")),
+        () -> assertEquals(booleanValue(true), tupleValue("{\"boolV\":1}").get("boolV")),
+        () -> assertEquals(booleanValue(false), tupleValue("{\"boolV\":0}").get("boolV")),
         () -> assertEquals(booleanValue(true), constructFromObject("boolV", true)),
         () -> assertEquals(booleanValue(true), constructFromObject("boolV", "true")),
         () -> assertEquals(booleanValue(true), constructFromObject("boolV", 1)),

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/response/OpenSearchAggregationResponseParserTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/response/OpenSearchAggregationResponseParserTest.java
@@ -581,4 +581,177 @@ class OpenSearchAggregationResponseParserTest {
   public Map<String, Object> entry(String name, Object value, String name2, Object value2) {
     return ImmutableMap.of(name, value, name2, value2);
   }
+
+  /**
+   * Test that TopHitsParser with fieldRenameMapping correctly renames response keys. This verifies
+   * the fix for https://github.com/opensearch-project/sql/issues/5150 where dedup pushdown
+   * aggregation returns null for renamed fields because the response uses original field names but
+   * the enumerator expects renamed names.
+   */
+  @Test
+  void top_hits_with_rename_mapping_should_remap_field_names() {
+    // Simulates: source=idx | rename value as val | dedup category | fields category, val
+    // The top_hits response uses original field name "value" from _source,
+    // but the enumerator expects "val" from the rowType.
+    String response =
+        "{\n"
+            + "  \"composite#composite_buckets\": {\n"
+            + "    \"buckets\": [\n"
+            + "      {\n"
+            + "        \"key\": {\n"
+            + "          \"category\": \"A\"\n"
+            + "        },\n"
+            + "        \"doc_count\": 2,\n"
+            + "        \"top_hits#dedup\": {\n"
+            + "          \"hits\": {\n"
+            + "            \"total\": { \"value\": 2, \"relation\": \"eq\" },\n"
+            + "            \"max_score\": 1.0,\n"
+            + "            \"hits\": [\n"
+            + "              {\n"
+            + "                \"_index\": \"idx\",\n"
+            + "                \"_id\": \"1\",\n"
+            + "                \"_score\": 1.0,\n"
+            + "                \"_source\": {\n"
+            + "                  \"category\": \"A\",\n"
+            + "                  \"value\": 10.5\n"
+            + "                }\n"
+            + "              }\n"
+            + "            ]\n"
+            + "          }\n"
+            + "        }\n"
+            + "      },\n"
+            + "      {\n"
+            + "        \"key\": {\n"
+            + "          \"category\": \"B\"\n"
+            + "        },\n"
+            + "        \"doc_count\": 1,\n"
+            + "        \"top_hits#dedup\": {\n"
+            + "          \"hits\": {\n"
+            + "            \"total\": { \"value\": 1, \"relation\": \"eq\" },\n"
+            + "            \"max_score\": 1.0,\n"
+            + "            \"hits\": [\n"
+            + "              {\n"
+            + "                \"_index\": \"idx\",\n"
+            + "                \"_id\": \"3\",\n"
+            + "                \"_score\": 1.0,\n"
+            + "                \"_source\": {\n"
+            + "                  \"category\": \"B\",\n"
+            + "                  \"value\": 100.0\n"
+            + "                }\n"
+            + "              }\n"
+            + "            ]\n"
+            + "          }\n"
+            + "        }\n"
+            + "      }\n"
+            + "    ]\n"
+            + "  }\n"
+            + "}";
+    // With rename mapping: "value" -> "val"
+    OpenSearchAggregationResponseParser parser =
+        new CompositeAggregationParser(
+            new TopHitsParser("dedup", false, false, Map.of("value", "val")));
+    List<Map<String, Object>> result = parse(parser, response);
+    // Verify renamed field "val" appears instead of "value"
+    assertThat(
+        result,
+        contains(
+            ImmutableMap.of("category", "A"),
+            ImmutableMap.of("category", "A", "val", 10.5),
+            ImmutableMap.of("category", "B"),
+            ImmutableMap.of("category", "B", "val", 100.0)));
+  }
+
+  /**
+   * Test that TopHitsParser without rename mapping preserves original field names (backward
+   * compatibility).
+   */
+  @Test
+  void top_hits_without_rename_mapping_should_preserve_original_names() {
+    String response =
+        "{\n"
+            + "  \"composite#composite_buckets\": {\n"
+            + "    \"buckets\": [\n"
+            + "      {\n"
+            + "        \"key\": {\n"
+            + "          \"category\": \"A\"\n"
+            + "        },\n"
+            + "        \"doc_count\": 1,\n"
+            + "        \"top_hits#dedup\": {\n"
+            + "          \"hits\": {\n"
+            + "            \"total\": { \"value\": 1, \"relation\": \"eq\" },\n"
+            + "            \"max_score\": 1.0,\n"
+            + "            \"hits\": [\n"
+            + "              {\n"
+            + "                \"_index\": \"idx\",\n"
+            + "                \"_id\": \"1\",\n"
+            + "                \"_score\": 1.0,\n"
+            + "                \"_source\": {\n"
+            + "                  \"category\": \"A\",\n"
+            + "                  \"value\": 10.5\n"
+            + "                }\n"
+            + "              }\n"
+            + "            ]\n"
+            + "          }\n"
+            + "        }\n"
+            + "      }\n"
+            + "    ]\n"
+            + "  }\n"
+            + "}";
+    // No rename mapping
+    OpenSearchAggregationResponseParser parser =
+        new CompositeAggregationParser(new TopHitsParser("dedup", false, false));
+    List<Map<String, Object>> result = parse(parser, response);
+    // Original field name "value" should be preserved
+    assertThat(
+        result,
+        contains(
+            ImmutableMap.of("category", "A"),
+            ImmutableMap.of("category", "A", "value", 10.5)));
+  }
+
+  /**
+   * Test that TopHitsParser with multiple renames maps all fields correctly. See
+   * https://github.com/opensearch-project/sql/issues/5150
+   */
+  @Test
+  void top_hits_with_multiple_renames_should_remap_all_fields() {
+    String response =
+        "{\n"
+            + "  \"composite#composite_buckets\": {\n"
+            + "    \"buckets\": [\n"
+            + "      {\n"
+            + "        \"key\": {\n"
+            + "          \"id\": 1\n"
+            + "        },\n"
+            + "        \"doc_count\": 1,\n"
+            + "        \"top_hits#dedup\": {\n"
+            + "          \"hits\": {\n"
+            + "            \"total\": { \"value\": 1, \"relation\": \"eq\" },\n"
+            + "            \"max_score\": 1.0,\n"
+            + "            \"hits\": [\n"
+            + "              {\n"
+            + "                \"_index\": \"idx\",\n"
+            + "                \"_id\": \"1\",\n"
+            + "                \"_score\": 1.0,\n"
+            + "                \"_source\": {\n"
+            + "                  \"name\": \"Alice\",\n"
+            + "                  \"salary\": 5000\n"
+            + "                }\n"
+            + "              }\n"
+            + "            ]\n"
+            + "          }\n"
+            + "        }\n"
+            + "      }\n"
+            + "    ]\n"
+            + "  }\n"
+            + "}";
+    // Rename both fields: "name" -> "employee", "salary" -> "pay"
+    OpenSearchAggregationResponseParser parser =
+        new CompositeAggregationParser(
+            new TopHitsParser("dedup", false, false, Map.of("name", "employee", "salary", "pay")));
+    List<Map<String, Object>> result = parse(parser, response);
+    assertThat(
+        result,
+        contains(ImmutableMap.of("id", 1), ImmutableMap.of("employee", "Alice", "pay", 5000)));
+  }
 }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLDedupTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLDedupTest.java
@@ -229,6 +229,27 @@ public class CalcitePPLDedupTest extends CalcitePPLAbstractTest {
     verifyLogical(root, expectedLogical);
   }
 
+  /**
+   * Verify that rename + dedup on a different field produces a correct logical plan. The renamed
+   * field should appear in the plan with the renamed name, not the original. See
+   * https://github.com/opensearch-project/sql/issues/5150
+   */
+  @Test
+  public void testRenameThenDedupOnDifferentField() {
+    // rename SAL as salary, then dedup on DEPTNO -- salary should preserve the renamed name
+    String ppl = "source=EMP | rename SAL as SALARY | dedup DEPTNO | fields DEPTNO, SALARY, ENAME";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalProject(DEPTNO=[$0], SALARY=[$1], ENAME=[$2])\n"
+            + "  LogicalFilter(condition=[<=($3, 1)])\n"
+            + "    LogicalProject(DEPTNO=[$0], SALARY=[$1], ENAME=[$2],"
+            + " _row_number_dedup_=[ROW_NUMBER() OVER (PARTITION BY $0)])\n"
+            + "      LogicalFilter(condition=[IS NOT NULL($0)])\n"
+            + "        LogicalProject(DEPTNO=[$7], SALARY=[$5], ENAME=[$1])\n"
+            + "          LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+  }
+
   @Test
   public void testRenameDedup() {
     String ppl =


### PR DESCRIPTION
### Description

When a field is renamed via `rename` and a subsequent `dedup` operates on a different field, the aggregation-based `DedupPushdownRule` returns null for all renamed fields. This is because the `top_hits` response uses original index field names from `_source`, but the `OpenSearchIndexEnumerator` expects the renamed names from the logical plan's `rowType`.

**Root cause**: In `AggregateAnalyzer.createTopHitsBuilder()`, `helper.inferNamedField()` resolves `RexInputRef` fields to original index names (e.g., `value`), but the enumerator's field list uses renamed names (e.g., `val`). No mapping bridges this gap.

**Fix**: Build a rename mapping (`originalName -> renamedName`) in the `LITERAL_AGG` case of `AggregateAnalyzer` by comparing the resolved index field name with the project's field name. Pass this mapping to `TopHitsParser`, which applies it when constructing result maps from the `_source` response.

### Related Issues
Resolves opensearch-project/sql#5150

### Check List
- [x] New functionality includes testing
- [x] Commits signed per DCO (`-s`)
- [x] `spotlessCheck` passed
- [x] Unit tests passed
- [x] Integration tests passed